### PR TITLE
Change to LLNL not PCMDI

### DIFF
--- a/esgf-prod/esgf_known_providers.xml
+++ b/esgf-prod/esgf_known_providers.xml
@@ -38,7 +38,7 @@
   <URL>https://</URL>
  </OP>
  <OP>
-  <NAME>DOE (LLNL) Program for Climate Model Diagnostics and Intercomparison (PCMDI)</NAME>
+  <NAME>DOE Lawrence Livermore National Laboratory (LLNL)/NAME>
   <URL>https://pcmdi9.llnl.gov/esgf-idp/openid/</URL>
  </OP>
  <OP>

--- a/esgf-prod/esgf_shards_static.xml
+++ b/esgf-prod/esgf_shards_static.xml
@@ -12,7 +12,7 @@
 
     <!-- America -->
     <value>esgf-node.jpl.nasa.gov/solr</value>
-
+    <value>pcmdi9.llnl.gov/solr</value>
     <!-- Asia -->
 
     <!-- Australia -->

--- a/esgf-test/esgf_ats_static.xml
+++ b/esgf-test/esgf_ats_static.xml
@@ -15,5 +15,11 @@
                attributeService="https://pcmdi9.llnl.gov/esgf-idp/saml/soap/secure/attributeService.htm"
                description="Users of CMIP5 data for commercial purposes"
                registrationService="https://pcmdi9.llnl.gov/esgf-idp/secure/registrationService.htm"/>
-               
+        
+        
+                <attribute type="LLNL"
+               attributeService="https://pcmdi11.llnl.gov/esgf-idp/saml/soap/secure/attributeService.htm"
+               registrationService="https://pcmdi11.llnl.gov/esgf-idp/secure/registrationService.htm"
+                description="desc"/>
+       
  </ats_whitelist>

--- a/esgf-test/esgf_idp_static.xml
+++ b/esgf-test/esgf_idp_static.xml
@@ -7,7 +7,7 @@
 
     <!-- America -->
     <value>https://esgf-dev.jpl.nasa.gov/esgf-idp/idp/openidServer.htm</value>
-
+    <value>https://pcmdi11.llnl.gov/esgf-idp/idp/openidServer.htm</value>
     <!-- Europe -->
 
 </idp_whitelist>

--- a/esgf-test/esgf_known_providers.xml
+++ b/esgf-test/esgf_known_providers.xml
@@ -42,11 +42,6 @@
 
  <!-- America -->
  <OP>
-  <!--
-	Identity Provider Organisation name to be displayed in ORP user interface combobox
-	The first entry is blank to indicate to the user that they can type in their
-	own if needed
-  -->
   <NAME>DOE Lawrence Livermore National Lab (LLNL)</NAME>
   <URL>https://pcmdi11.llnl.gov/esgf-idp/openid</URL>
  </OP>

--- a/esgf-test/esgf_known_providers.xml
+++ b/esgf-test/esgf_known_providers.xml
@@ -41,6 +41,15 @@
  <!-- Africa -->
 
  <!-- America -->
+ <OP>
+  <!--
+	Identity Provider Organisation name to be displayed in ORP user interface combobox
+	The first entry is blank to indicate to the user that they can type in their
+	own if needed
+  -->
+  <NAME>DOE Lawrence Livermore National Lab (LLNL)</NAME>
+  <URL>https://pcmdi11.llnl.gov/esgf-idp/openid</URL>
+ </OP>
 
  <!-- Asia -->
 

--- a/esgf-test/esgf_shards_static.xml
+++ b/esgf-test/esgf_shards_static.xml
@@ -11,7 +11,7 @@
     <!-- Africa -->
 
     <!-- America -->
-
+    <value>pcmdi11.llnl.gov/solr</value>
     <!-- Asia -->
 
     <!-- Australia -->


### PR DESCRIPTION
Luca, You were right the first time.  We need to stop having PCMDI as the institute listed.
Thanks,
Sasha
