### PR TITLE
Update esg.cmip6.ini

### DIFF
--- a/publisher-configs/ini/esg.cmip6.ini
+++ b/publisher-configs/ini/esg.cmip6.ini
@@ -325,6 +325,8 @@ institute_map = map(model : institute)
 
 handler = esgcet.config.cmip6_handler:CMIP6Handler
 
+create_cim = true
+
 las_configure = true
 
 thredds_exclude_variables = a, a_bnds, alev1, alevel, alevhalf, alt40, b, b_bnds, basin, bnds, bounds_lat, bounds_lon, dbze, depth, depth0m, depth100m, depth_bnds, geo_region, height, height10m, height2m, lat, lat_bnds, latitude, latitude_bnds, layer, lev, lev_bnds, location, lon, lon_bnds, longitude, longitude_bnds, olayer100m, olevel, oline, p0, p220, p500, p560, p700, p840, plev, plev3, plev7, plev8, plev_bnds, plevs, pressure1, region, rho, scatratio, sdepth, sdepth1, sza5, tau, tau_bnds, time, time1, time2, time_bnds, vegtype


### PR DESCRIPTION
Set the default for the "create CIM" behaviour to true for CMIP6, as discussed on a recent PWT telco.

This variable will be honoured by the code which has been committed to https://github.com/IS-ENES-Data/esg-publisher/tree/cim-integration-2, and which is the subject of a pull request at https://github.com/IS-ENES-Data/esg-publisher/pull/3, which I have asked for people at IS-ENES-Data team to review, hopefully merge into IS-ENES-Data/esg-publisher/devel and then create an onward pull request into ESGF/esg-publisher/devel.  If that pull request comes your way, then this one should be merged to accompany it.