### PR TITLE
add esgf-index3.ceda.ac.uk

### DIFF
--- a/esgf-prod/esgf_shards_static.xml
+++ b/esgf-prod/esgf_shards_static.xml
@@ -29,6 +29,7 @@ custom configuration of replica nodes.
     <value>esgf-node.ipsl.upmc.fr/solr</value>
     <value>esg-dn1.nsc.liu.se/solr</value>
     <value>esgf-index1.ceda.ac.uk/solr</value>
+    <value>esgf-index3.ceda.ac.uk/solr</value> <!-- for Tier 2 nodes that publish to CEDA -->
     <value>esg.pik-potsdam.de/solr</value>
      
 </shards>


### PR DESCRIPTION
The index on esgf-index3.ceda.ac.uk is used for Tier 2 nodes that publish to CEDA - so far only Barcelona Supercomputing Centre.
This is in addition to esgf-index1.ceda.ac.uk, which is used for data published by CEDA.

External sites should point to both of these shards (or replicas of them), because nothing is done to merge them within Solr.